### PR TITLE
switchboard port changed to 11911 to accomodate ros2 stack

### DIFF
--- a/src/duckietown/sdk/robots/duckiebot/generic.py
+++ b/src/duckietown/sdk/robots/duckiebot/generic.py
@@ -6,7 +6,7 @@ from ...middleware.dtps.components import DTPSCameraDriver, DTPSTimeOfFlightDriv
 from ...types import CompoundComponent
 
 
-DEFAULT_ROBOT_SWITCHBOARD_PORT: int = 11511
+DEFAULT_ROBOT_SWITCHBOARD_PORT: int = 11911
 DEFAULT_DUCKIEMATRIX_PORT: int = 7501
 
 


### PR DESCRIPTION
We need to change port `11511` everywhere in our stack to support ROS2 as it is used in the topic discovery daemon.